### PR TITLE
workflows: disable persist-credentials

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
       - run: |
           yarn


### PR DESCRIPTION
zizmor [flagged][1] [artipacked][2] as a potential mistake, and now that we're not using credentials to auto-commit the prettier fixes, we don't need credentials on disk at all.

[1]: https://docs.zizmor.sh/audits/#artipacked
[2]: https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/