### PR TITLE
Fill in Index page content

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,17 @@
           </h2>
           <!--<h2><a href="">Resources</a></h2>-->
         </div>
+        <hr />
+        <div>
+          <p>
+            Problem with our new website?<br />
+            <a
+              href="http://github.com/connectionsmuseum/public-web/issues"
+              target="_blank"
+              >Let us know on GitHub!</a
+            >
+          </p>
+        </div>
       </r-cell>
     </r-grid>
   </body>

--- a/index.html
+++ b/index.html
@@ -239,12 +239,12 @@
             >
           </h6>
           <br />
-          <h6>
+          <p>
             Want to send us something?
             <a href="support.html#mailing_address"
               >Information about mailing donations.</a
             >
-          </h6>
+          </p>
         </div>
       </r-cell>
       <r-cell span="1">

--- a/index.html
+++ b/index.html
@@ -83,29 +83,33 @@
     </r-grid>
     <r-grid columns="4" columns-s="1">
       <r-cell class="only-small-window" span="row">
-        <h1>Visiting the Connections Museum?</h1>
+        <h1>Visiting our Seattle museum?</h1>
         <h3>Here's a few things you should know...</h3>
         <div class="callout">
           <!--<h2>The Seattle museum will be closed on Sunday, September 21st, due to other staffing needs that day. More info at the link below.</h2>-->
           <h4>
-            We're open almost every Sunday from 10am to 3pm. Last tour at about
-            2:30. If you are really technical, or a big fan, you'll probably
-            want to arrive before 1pm to see everything. The suggested donation
-            is $10 for adults. ⌘&nbsp;<a href="seattle.html"
-              >More info about our Seattle Museum — Hours, Directions, & Tour
-              Information</a
-            >
+            We're open almost every Sunday from 10am to 3pm. The last tour
+            starts at about 2:30. If you are really technical, or a big fan,
+            you'll probably want to arrive before 1pm to see everything.
           </h4>
           <h4>
-            Located at
+            We're located at
             <a
               href="maps:?q=$Connections Museum, 7000 E Marginal Way S, Seattle, WA 98108"
               target="_blank"
               >7000 E Marginal Way S, Seattle, WA 98108</a
             >
           </h4>
+          <h4>The suggested donation is $10 for adults.</h4>
           <h4>
-            Need something right now? Call us at
+            ⌘&nbsp;<a href="seattle.html"
+              >We have more detailed information for visitors with disabilities,
+              or those arriving with large groups, children, and animals on our
+              Seattle Museum page.
+            </a>
+          </h4>
+          <h4>
+            Still have questions? Call us at
             <a href="tel:+12067673012">(206) 767–3012</a>
           </h4>
         </div>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
           </h4>
           <h4>
             Need something right now? Call us at
-            <a href="tel:+12067673012">(206) ROckwell 7–3012</a>
+            <a href="tel:+12067673012">(206) 767–3012</a>
           </h4>
         </div>
       </r-cell>

--- a/index.html
+++ b/index.html
@@ -161,8 +161,13 @@
             >
             is located in the historic 931 14th Street building in Denver and
             includes the original executive offices and Allen Tupper True
-            murals. Tours are available by appointment.
+            murals. <i>Tours are available by appointment.</i>
           </p>
+          <h3>
+            ፠
+            <a href="denver.html#downtown">About Our Denver Museum</a>
+          </h3>
+          <br />
           <p>
             <b>Connections Museum Colorado</b>
             is currently under active construction of our new building,

--- a/index.html
+++ b/index.html
@@ -159,13 +159,13 @@
             murals. Tours are available by appointment.
           </p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
+            <!--<a href="denver.html#arvada"></a>--><b
+              >Connections Museum Colorado</b
+            >
+            is currently under active construction of our new building,
+            exhibits, and volunteer docent group. We hope to have the museum
+            open soon! It will be located in Arvada, Colorado, walkable from
+            <b>RTD's 60th/Sheridan-Arvada Gold Strike Station</b>.
           </p>
           <h3>
             ፠

--- a/index.html
+++ b/index.html
@@ -186,7 +186,8 @@
             →
             <a
               href="https://www.youtube.com/watch?v=RBXu7qJ7dNQ&list=PLm8mbrpAteNnJd5OOXEiONSqwawlf9nqo"
-              >Watch our YouTube video series to follow along as we set up!</a
+              >Check out our YouTube video series to follow along as we set
+              up!</a
             >
           </p>
           <p>
@@ -263,7 +264,7 @@
         <h3>
           →
           <a href="https://www.youtube.com/@ConnectionsMuseum" class="callout"
-            >Check out our YouTube channel!</a
+            >Subscribe to our YouTube channel!</a
           >
         </h3>
         <h3>

--- a/index.html
+++ b/index.html
@@ -126,11 +126,14 @@
           </p>
           <p>
             If you live in or visit the Seattle area, come check out our
-            one-of-a-kind museum, filled with rare switching artifacts, familiar
+            one-of-a-kind museum, housed in an active telephone company Central
+            Office and packed full of rare switching artifacts, familiar
             telephone sets and payphone booths, interactive displays, and aisles
             of working telecom equipment, all restored to incredible condition.
             Our most exciting equipment is the last example in the entire world,
-            and you can try it out, exactly as it was back in 1923! We have
+            and you can try it out, exactly as it was back in 1923! Unless you
+            worked for AT&T or the Bell System during the middle of the last
+            century, you've never seen anything quite like our museum. We have
             informative docents and passionate volunteers who are excited to
             show you around. We're just a short drive up the road from the
             Museum of Flight.

--- a/index.html
+++ b/index.html
@@ -132,7 +132,10 @@
             culpa qui officia deserunt mollit anim id est laborum.
           </p>
           <h3>
-            ⌘ <a href="seattle.html">Hours, Directions, & Tour Information</a>
+            ⌘
+            <a href="seattle.html"
+              >Seattle Museum Hours, Directions, & Tour Information</a
+            >
           </h3>
           <hr />
           <h4>
@@ -184,7 +187,6 @@
               >Watch our announcement YouTube video series!</a
             >
           </p>
-          <!--<p> ፠&nbsp;<a href="denver.html#arvada">More info.</a></p>-->
         </div>
       </r-cell>
       <r-cell span="1" class="only-large-window">

--- a/index.html
+++ b/index.html
@@ -195,15 +195,21 @@
         <div id="archives-info">
           <h2>Archives</h2>
           <p>
-            The THG Archives, located in Denver, Colorado, includes telephone
-            directories, over 100,000 photographs and slides, historic business
-            records, and other items. Research services are available from our
-            staff or in person by visitors.
-            <a href="denver.html#archives">More info.</a>
+            The <b>THG Archives</b>, located in downtown Denver, contain
+            telephone directories, over 100,000 photographs and slides, historic
+            business records, and other items.
+            <a href="denver.html#archives"
+              >Research services are available from our staff or in person by
+              visitors.</a
+            >
           </p>
           <p>
-            Also, the Connections Museum Seattle operates a reference library.
-            <a href="seattle.html#library">More info.</a>
+            The Connections Museum Seattle operates a reference library of
+            information related to our region and the equipment we maintain.
+            <a href="seattle.html#library"
+              >Contributions of materials greatly appreciated. Digitization of
+              our technical documentation is available upon request.</a
+            >
           </p>
         </div>
         <hr />
@@ -236,7 +242,7 @@
           <h6>
             Want to send us something?
             <a href="support.html#mailing_address"
-              >Click here for information about mailing donations.</a
+              >Information about mailing donations.</a
             >
           </h6>
         </div>

--- a/index.html
+++ b/index.html
@@ -124,6 +124,12 @@
               >Open most Sundays, 10am–3pm.</b
             >
           </p>
+          <h3>
+            ⌘
+            <a href="seattle.html"
+              >Seattle Museum Hours, Directions, & Tour Information</a
+            >
+          </h3>
           <p>
             If you live in or visit the Seattle area, come check out our
             one-of-a-kind museum, housed in an active telephone company Central
@@ -138,12 +144,6 @@
             show you around. We're just a short drive up the road from the
             Museum of Flight.
           </p>
-          <h3>
-            ⌘
-            <a href="seattle.html"
-              >Seattle Museum Hours, Directions, & Tour Information</a
-            >
-          </h3>
           <hr />
           <h4>
             More updates to come soon on the new home for the "JKL" American

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             We're open almost every Sunday from 10am to 3pm. Last tour at about
             2:30. If you are really technical, or a big fan, you'll probably
             want to arrive before 1pm to see everything. The suggested donation
-            is $10 for adults. ፠&nbsp;<a href="seattle.html"
+            is $10 for adults. ⌘&nbsp;<a href="seattle.html"
               >More info about our Seattle Museum — Hours, Directions, & Tour
               Information</a
             >
@@ -165,6 +165,10 @@
             pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
             culpa qui officia deserunt mollit anim id est laborum.
           </p>
+          <h3>
+            ፠
+            <a href="denver.html">About Our Denver & Arvada Museums</a>
+          </h3>
           <hr />
           <h4>More information to come soon on our new museum in Arvada!</h4>
           <p>
@@ -188,14 +192,12 @@
             The THG Archives, located in Denver, Colorado, includes telephone
             directories, over 100,000 photographs and slides, historic business
             records, and other items. Research services are available from our
-            staff or in person by visitors. ፠&nbsp;<a
-              href="denver.html#archives"
-              >More info.</a
-            >
+            staff or in person by visitors.
+            <a href="denver.html#archives">More info.</a>
           </p>
           <p>
             Also, the Connections Museum Seattle operates a reference library.
-            ፠&nbsp;<a href="seattle.html#library">More info.</a>
+            <a href="seattle.html#library">More info.</a>
           </p>
         </div>
         <hr />

--- a/index.html
+++ b/index.html
@@ -117,10 +117,10 @@
         <div id="seattle-info">
           <h2>Seattle, Wash.</h2>
           <p>
-            Connections Museum Seattle, formerly the Herbert H. Warrick Jr.
-            Museum of Communications, boasts an extensive collection of
+            <b>Connections Museum Seattle</b>, formerly the Herbert H. Warrick
+            Jr. Museum of Communications, boasts an extensive collection of
             switching equipment, telephones, central office and outside plant
-            equipment. Open every Sunday.
+            equipment.<br /><b>Open most Sundays, 10am–3pm.</b>
           </p>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -151,10 +151,12 @@
         <div id="denver-info">
           <h2>Denver, Colo.</h2>
           <p>
-            Connections Museum Denver is located in the historic 931 14th Street
-            building in Denver and includes the original executive offices and
-            Allen Tupper True murals. Tours are available by appointment.
-            ፠&nbsp;<a href="denver.html#downtown">More info.</a>
+            <!--<a href="denver.html#downtown"></a>--><b
+              >Connections Museum Denver</b
+            >
+            is located in the historic 931 14th Street building in Denver and
+            includes the original executive offices and Allen Tupper True
+            murals. Tours are available by appointment.
           </p>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
         <div id="seattle-info">
           <h2>Seattle, Wash.</h2>
           <p>
-            Connections Museum Seattle, formerly the Herbert H. Warrick, Jr.
+            Connections Museum Seattle, formerly the Herbert H. Warrick Jr.
             Museum of Communications, boasts an extensive collection of
             switching equipment, telephones, central office and outside plant
             equipment. Open every Sunday.

--- a/index.html
+++ b/index.html
@@ -117,10 +117,12 @@
         <div id="seattle-info">
           <h2>Seattle, Wash.</h2>
           <p>
-            <b>Connections Museum Seattle</b>, formerly the Herbert H. Warrick
-            Jr. Museum of Communications, boasts an extensive collection of
-            switching equipment, telephones, central office and outside plant
-            equipment.<br /><b>Open most Sundays, 10am–3pm.</b>
+            <b>Connections Museum Seattle</b>, formerly the
+            <i>Herbert H. Warrick Jr. Museum of Communications</i>, boasts an
+            extensive collection of switching equipment, telephones, central
+            office and outside plant equipment.<br /><b
+              >Open most Sundays, 10am–3pm.</b
+            >
           </p>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/index.html
+++ b/index.html
@@ -120,8 +120,8 @@
             <b>Connections Museum Seattle</b>, formerly the
             <i>Herbert H. Warrick Jr. Museum of Communications</i>, boasts an
             extensive collection of switching equipment, telephones, central
-            office and outside plant equipment.<br /><b
-              >Open most Sundays, 10am–3pm.</b
+            office and outside plant equipment.<br /><i
+              >Open most Sundays, 10am–3pm.</i
             >
           </p>
           <h3>

--- a/index.html
+++ b/index.html
@@ -125,13 +125,15 @@
             >
           </p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
+            If you live in or visit the Seattle area, come check out our
+            one-of-a-kind museum, filled with rare switching artifacts, familiar
+            telephone sets and payphone booths, interactive displays, and aisles
+            of working telecom equipment, all restored to incredible condition.
+            Our most exciting equipment is the last example in the entire world,
+            and you can try it out, exactly as it was back in 1923! We have
+            informative docents and passionate volunteers who are excited to
+            show you around. We're just a short drive up the road from the
+            Museum of Flight.
           </p>
           <h3>
             ⌘

--- a/index.html
+++ b/index.html
@@ -164,30 +164,36 @@
             murals. Tours are available by appointment.
           </p>
           <p>
-            <!--<a href="denver.html#arvada"></a>--><b
-              >Connections Museum Colorado</b
-            >
+            <b>Connections Museum Colorado</b>
             is currently under active construction of our new building,
             exhibits, and volunteer docent group. We hope to have the museum
             open soon! It will be located in Arvada, Colorado, walkable from
-            <b>RTD's 60th/Sheridan-Arvada Gold Strike Station</b>.
+            <!--<a
+              href="maps:?q=$C"
+              target="_blank"
+              ></a>-->RTD's 60th/Sheridan-Arvada Gold Strike Station.
           </p>
-          <h3>
+          <!--<h3>
             ፠
-            <a href="denver.html">About Our Denver & Arvada Museums</a>
-          </h3>
-          <hr />
-          <h4>More information to come soon on our new museum in Arvada!</h4>
-          <p>
-            Please <a href="volunteer.html">sign up here</a> if you'd like to be
-            one of our early volunteers and help build our new museum!
-          </p>
+            <a href="denver.html#downtown">About Our Upcoming Arvada Museum</a>
+          </h3>-->
           <p>
             →
             <a
               href="https://www.youtube.com/watch?v=RBXu7qJ7dNQ&list=PLm8mbrpAteNnJd5OOXEiONSqwawlf9nqo"
-              >Watch our announcement YouTube video series!</a
+              >Watch our YouTube video series to follow along as we set up!</a
             >
+          </p>
+          <p>
+            If you live in the area and are passionate about telecommunications
+            and mechanical technology, please
+            <a href="volunteer.html">sign up here</a> if you'd like to be one of
+            our early volunteers helping build our new museum!
+          </p>
+          <p>
+            Otherwise, please consider
+            <a href="support.html#donate">making a financial contribution</a> to
+            show your support!
           </p>
         </div>
       </r-cell>

--- a/museum.css
+++ b/museum.css
@@ -191,4 +191,12 @@ a.callout {
   #title {
     font-size: 3rem;
   }
+  
+@media only screen and (max-width: 450px) {
+  #logo {
+    max-height: 2.5rem;
+  }
+  #title {
+    font-size: 2.5rem;
+  }
 }

--- a/museum.css
+++ b/museum.css
@@ -145,7 +145,7 @@ a.callout {
 
 /* LAYOUT */
 
-@media only screen and (max-width: 1450px) {
+@media only screen and (max-width: 1550px) {
   #logo {
     max-height: 9rem;
   }
@@ -154,7 +154,7 @@ a.callout {
   }
 }
 
-@media only screen and (max-width: 1250px) {
+@media only screen and (max-width: 1350px) {
   #logo {
     max-height: 7rem;
   }
@@ -163,7 +163,7 @@ a.callout {
   }
 }
 
-@media only screen and (max-width: 1050px) {
+@media only screen and (max-width: 1150px) {
   .header {
     float: right;
   }

--- a/museum.css
+++ b/museum.css
@@ -191,7 +191,8 @@ a.callout {
   #title {
     font-size: 3rem;
   }
-  
+}
+
 @media only screen and (max-width: 450px) {
   #logo {
     max-height: 2.5rem;

--- a/seattle.html
+++ b/seattle.html
@@ -178,20 +178,20 @@
       <r-cell span="2" span-s="1">
         <h2>Safety</h2>
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum
-          dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-          incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-          commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-          velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-          occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-          mollit anim id est laborum.
+          Live electricity is exposed in many non-obvious places, and rotating
+          machinery can catch on clothing. Such is the nature of running
+          equipment as old as ours-some is over 100 years old! We do our best to
+          ensure a safe environment despite this, and all tours should begin
+          with a quick safety briefing.
+        </p>
+        <p>
+          Many of our artifacts are old and irreplaceable, but with just a few
+          exceptions, we prefer to not put them away "under glass." So our
+          simple rule is this:
+          <b
+            >Please ask one of our volunteer guides before you pick up items on
+            display or interact with our machines.</b
+          >
         </p>
       </r-cell>
       <r-cell span="4" span-s="1">

--- a/seattle.html
+++ b/seattle.html
@@ -153,6 +153,8 @@
         </p>
         <h3>Pets</h3>
         <p>We only allow trained service animals inside the museum.</p>
+        <h3>COVID</h3>
+        <p>Masks are welcomed, but not required.</p>
       </r-cell>
       <r-cell span="row">
         <h4>

--- a/support.html
+++ b/support.html
@@ -96,6 +96,7 @@
           <a
             class="callout"
             href="https://www.paypal.com/donate/?hosted_button_id=WYFRCDFV4X4VW"
+            style="text-decoration-style: wavy; text-underline-offset: 0.2em"
             >Please help support us!</a
           >
         </h1>

--- a/support.html
+++ b/support.html
@@ -220,14 +220,14 @@
             >More information about our efforts therein are provided here</a
           >.
         </p>
-        <h3>Our Mailing Address</h3>
+        <h3 id="mailing_address">Our Mailing Address</h3>
         <p>
-          Letters of appreciation and personal stories of telecommunications
-          welcomed. Before mailing us documents or artifacts, please be sure to
-          email us at one of the addresses on this page beforehand to ensure
-          your donation is properly accessed into our collection.
+          Letters of appreciation and personal stories of telecommunications are
+          always welcome. If you'd like to mail us documents or artifacts,
+          please be sure to send us an email beforehand to ensure your donation
+          is properly accessed into our collection.
         </p>
-        <r-grid columns="2" id="mailing_address">
+        <r-grid columns="2">
           <r-cell span="1">
             <pre>
               <code>

--- a/support.html
+++ b/support.html
@@ -112,6 +112,11 @@
           years to come. If you're not quite sure what we're talking about,
           <a href="https://www.youtube.com/watch?v=6bqt_nTwod4"
             >watch this short video to see it for yourself</a
+          >, or check out
+          <a
+            href="https://web.archive.org/web/20250404150529/https://www.seattletimes.com/pacific-nw-magazine/from-old-phones-to-volunteers-everything-clicks-at-the-connections-museum/"
+            >this feature article by the Seattle Times Pacific Northwest
+            Magazine</a
           >.
         </p>
       </r-cell>


### PR DESCRIPTION
### Highlights

- Removes the last bit of lorem ipsum text from the homepage.
- Reduces repetitive calls-to-action.
- Uses section markers and external link indicators consistently.
- Adjusts responsive breakpoints for page headers again as I noticed that they were not displaying correctly in Safari's simulated iPhone model viewport.

### Screenshots
<img width="2664" height="2514" alt="index_done" src="https://github.com/user-attachments/assets/235c90b2-bebb-4520-968f-7cc1c5af339d" />
